### PR TITLE
Adding new parameter for more dynamic horizontal query sharding

### DIFF
--- a/cmd/thanos/query_frontend.go
+++ b/cmd/thanos/query_frontend.go
@@ -73,8 +73,13 @@ func registerQueryFrontend(app *extkingpin.App) {
 	cmd.Flag("query-range.request-downsampled", "Make additional query for downsampled data in case of empty or incomplete response to range request.").
 		Default("true").BoolVar(&cfg.QueryRangeConfig.RequestDownsampled)
 
-	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured.").
+	cmd.Flag("query-range.split-interval", "Split query range requests by an interval and execute in parallel, it should be greater than 0 when query-range.response-cache-config is configured."+
+		"When used in conjunction with query-range.min-split-interval this becomes the upper boundary interval to split queries into.").
 		Default("24h").DurationVar(&cfg.QueryRangeConfig.SplitQueriesByInterval)
+
+	cmd.Flag("query-range.min-split-interval", "Split query range requests by at least this interval."+
+		"It also should be less than query-range.split-interval.").
+		Default("0").DurationVar(&cfg.QueryRangeConfig.MinQuerySplitInterval)
 
 	cmd.Flag("query-range.max-retries-per-request", "Maximum number of retries for a single query range request; beyond this, the downstream error is returned.").
 		Default("5").IntVar(&cfg.QueryRangeConfig.MaxRetries)

--- a/pkg/queryfrontend/config.go
+++ b/pkg/queryfrontend/config.go
@@ -219,6 +219,7 @@ type QueryRangeConfig struct {
 	AlignRangeWithStep     bool
 	RequestDownsampled     bool
 	SplitQueriesByInterval time.Duration
+	MinQuerySplitInterval  time.Duration
 	MaxRetries             int
 	Limits                 *cortexvalidation.Limits
 }


### PR DESCRIPTION
Signed-off-by: Pedro Tanaka <pedro.tanaka@shopify.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
